### PR TITLE
Allow tqdm to be overriden (to allow custom callbacks)

### DIFF
--- a/yabox/algorithms/de.py
+++ b/yabox/algorithms/de.py
@@ -174,9 +174,10 @@ class DE:
                 iteration = step.iteration
                 yield step
 
-    def solve(self, show_progress=False):
+    def solve(self, show_progress=False, tqdm=None):
         if show_progress:
-            from tqdm.auto import tqdm
+            if tqdm is None:
+                from tqdm.auto import tqdm
             iterator = tqdm(self.geniterator(), total=self.maxiters, desc='Optimizing ({0})'.format(self.name))
         else:
             iterator = self.geniterator()


### PR DESCRIPTION
In some cases, it might be desirable to override the choice of tqdm.auto for showing progress. Examples include:

- when autodetection is broken in jupyter qtconsole or similar [e.g. this issue](https://github.com/tqdm/tqdm/issues/1098)
- when a custom callback is desirable (e.g. updating a progressbar in a GUI toolkit without native support in tqdm)

Here we only use tqdm.auto if no wrapper for the generator (passed via a new tqdm kwarg) is supplied.